### PR TITLE
updated numpy & requests versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 bidict==0.22.1
 certifi==2022.12.7
 idna==2.10
-numpy==1.24.2
+numpy==1.26.4
 pyjsparser==2.7.1
 PyJWT==2.6.0
 python-dateutil==2.8.2
 python-dotenv==1.0.0
-requests==2.25.1
+requests==2.31
 six==1.16.0
 urllib3==1.26.14
 websocket-client==1.5.1

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ VERSION = "1.2.0"
 #
 # python setup.py install
 
-REQUIRES = ['bidict==0.22.1', 'certifi==2022.12.7', 'idna==2.10', 'numpy==1.24.2', 'pyjsparser==2.7.1', 'PyJWT==2.6.0',
-            'python-dateutil==2.8.2', 'python-dotenv==1.0.0', 'requests==2.25.1', 'six==1.16.0', 'urllib3==1.26.14',
+REQUIRES = ['bidict==0.22.1', 'certifi==2022.12.7', 'idna==2.10', 'numpy==1.26.4', 'pyjsparser==2.7.1', 'PyJWT==2.6.0',
+            'python-dateutil==2.8.2', 'python-dotenv==1.0.0', 'requests==2.31', 'six==1.16.0', 'urllib3==1.26.14',
             'websocket-client==1.5.1', 'websockets==8.1', 'pandas==2.0.0', 'asyncio==3.4.3']
 
 setup(


### PR DESCRIPTION
- updated `numpy` version to `1.26.4` because of python 3.12 compatibility issue, `pkgutil.ImpImporter` is not present ( https://stackoverflow.com/questions/77364550/attributeerror-module-pkgutil-has-no-attribute-impimporter-did-you-mean )
- updated `requests` version to `2.31`, as `yfinance 0.2.31` & `jupyterlab-server 2.25.2` needed the same

without this installation was failing for any python3.12+ 